### PR TITLE
RDKEMW-698 - [UK][RDKE/RDKV] Name field in hciconfig -a hci0

### DIFF
--- a/conf/xumotv-distros.inc
+++ b/conf/xumotv-distros.inc
@@ -25,3 +25,4 @@ DISTRO_FEATURES:append = ' enable_compositein_support'
 DISTRO_FEATURES:append = ' enable_spdif_support'
 DISTRO_FEATURES:append = ' enable_headphone_support'
 DISTRO_FEATURES:append = " btr_enable_auto_connect"
+DISTRO_FEATURES:append = " bt_adapter_name_xumo"


### PR DESCRIPTION
Reason for change: Remove the Adapter Name from meta-rdk-oss-reference and add distro feature for xumo
Test Procedure: Check the hcio adapter name
Risks: Medium
Priority: P1