### PR TITLE
RDKEMW-7010 : Playback failure in RDKE LLAMA builds

### DIFF
--- a/conf/xumotv-distros.inc
+++ b/conf/xumotv-distros.inc
@@ -1,6 +1,7 @@
 
 DISTRO_FEATURES:append = ' airplay'
 DISTRO_FEATURES:append = ' alsa'
+DISTRO_FEATURES:append = ' aamp_amlogic'
 DISTRO_FEATURES:append = ' build_rfc_enabled'
 DISTRO_FEATURES:append = ' cobalt_enable_evergreen_lite'
 DISTRO_FEATURES:append = ' comcast_qt5'


### PR DESCRIPTION
Reason for change: added distro feature in rdke-tv-config

Test Procedure: Test steps in ticket
Risks: Low
Priority: P2