### PR TITLE
RDKEMW-9018: [RDKE] Remove Netflix configs from meta-product layer

### DIFF
--- a/conf/profile.inc
+++ b/conf/profile.inc
@@ -30,8 +30,5 @@ AUTH_ACTIVATION_STATUS:platco = "true"
 #Dobby device specific settings
 DOBBY_DEVICESETTINGS_FILE = "dobby.llama.json"
 
-# Netflix specific configs 
-NETFLIX_MEDIA_CACHE_CAPACITY = "238MB"
-NETFLIX_MINAUDIOPTSGAP = "35"
 LINUXLIBCVERSION = "4.9%"
 


### PR DESCRIPTION
Reason for change: For common MW, app specific config needs to be moved out from common TV config
Test Procedure: Netflix launch and playback
Risks: Medium
Priority: P1