### PR TITLE
RDKEMW-14489: Cobalt widget file is having empty PMI for SKY LLAMA G1,G2,IT builds

### DIFF
--- a/conf/tv-uk.inc
+++ b/conf/tv-uk.inc
@@ -1,0 +1,4 @@
+#tv-us specific configs
+
+OVERRIDES .= ":rdktv-uk"
+MACHINEOVERRIDES .= ":rdkzram"


### PR DESCRIPTION
Reason for change: included tv-uk.inc 
Test Procedure:cobalt launch and playback
Risks: Medium
Priority: P1