### PR TITLE
RDKEMW-13635 : Nativeapp is not available

### DIFF
--- a/conf/tv-uk.inc
+++ b/conf/tv-uk.inc
@@ -1,0 +1,4 @@
+#tv-uk specific configs
+
+OVERRIDES .= ":rdktv-uk"
+MACHINEOVERRIDES .= ":rdkzram"


### PR DESCRIPTION
Reason for change: Adding tv-uk config to support common middleware
Test Procedure: see ticket
Risks: low
Priority: P2
Signed-off-by: Ezhilarasi Velumani [Ezhilarasi_Velumani@comcast.com](mailto:Ezhilarasi_Velumani@comcast.com)